### PR TITLE
Update AWS_XRAY_DAEMON_ADDRESS environment variable to include port

### DIFF
--- a/demo-app/k8s-deploy.yaml
+++ b/demo-app/k8s-deploy.yaml
@@ -39,7 +39,7 @@ spec:
             - name: API_CNAME
               value: service-b.default
             - name: AWS_XRAY_DAEMON_ADDRESS
-              value: xray-service.default
+              value: xray-service.default:2000
           resources:
             requests:
               cpu: 128m
@@ -90,7 +90,7 @@ spec:
               containerPort: 8080
           env:
             - name: AWS_XRAY_DAEMON_ADDRESS
-              value: xray-service.default
+              value: xray-service.default:2000
           resources:
             requests:
               cpu: 128m


### PR DESCRIPTION
*Issue #, if available:*

No issue # but was causing service pods to crash on launch in a loop.

*Description of changes:*

Adds the 2000 port number to the environment variable that the SDK is expecting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
